### PR TITLE
Fixed compilation in Fedora with g++ 6.3.1

### DIFF
--- a/stockassessment/src/stockassessment.cpp
+++ b/stockassessment/src/stockassessment.cpp
@@ -32,7 +32,6 @@
 #define TMB_LIB_INIT R_init_stockassessment
 #include <TMB.hpp>
 
-using CppAD::abs;
 
 /* Parameter transform */
 template <class Type>
@@ -50,6 +49,7 @@ bool isNAINT(int x){
 template <class Type>
 matrix<Type> setupVarCovMatrix(int minAge, int maxAge, int minAgeFleet, int maxAgeFleet, vector<int> rhoMap, vector<Type> rhoVec, vector<int> sdMap, vector<Type> sdVec){
 
+  using CppAD::abs;
   int dim = maxAgeFleet-minAgeFleet+1;
   int offset = minAgeFleet-minAge;
   matrix<Type> ret(dim,dim);
@@ -158,6 +158,7 @@ density::UNSTRUCTURED_CORR_t<Type> getCorrObj(vector<Type> params){
 template<class Type>
 Type objective_function<Type>::operator() ()
 {
+  using CppAD::abs;
   DATA_INTEGER(noFleets);
   DATA_IVECTOR(fleetTypes); 
   DATA_VECTOR(sampleTimes);


### PR DESCRIPTION
In Fedora, C++ 6.3.1 is confused on which abs() to use, despite `using CppAD::abs;` is already defined on top of the stockassessment.cpp file. Moving them inside the templates that are using `abs()` fixed it. Full error log follows.

```
> devtools::install_github("fishfollower/SAM/stockassessment")`
Downloading GitHub repo fishfollower/SAM@master
from URL https://api.github.com/repos/fishfollower/SAM/zipball/master
Installing stockassessment
'/usr/lib64/R/bin/R' --no-site-file --no-environ --no-save --no-restore  \
  --quiet CMD INSTALL  \
  '/tmp/RtmptDQYXO/devtools4c318c4795d/fishfollower-SAM-ffc854c/stockassessment'  \
  --library='/home/user/R/x86_64-redhat-linux-gnu-library/3.3'  \
  --install-tests

* installing *source* package ‘stockassessment’ ...
** libs
g++ -m64 -I/usr/include/R -DNDEBUG  -I/usr/local/include -I"/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include" -I"/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include"   -fpic  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic  -c stockassessment.cpp -o stockassessment.o
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Core:276:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Dense:1,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:53,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/Functors.h:973:28: warning: ‘template<class _Operation> class std::binder2nd’ is deprecated [-Wdeprecated-declarations]
 struct functor_traits<std::binder2nd<T> >
                            ^~~~~~~~~
In file included from /usr/include/c++/6.3.1/bits/stl_function.h:1127:0,
                 from /usr/include/c++/6.3.1/string:48,
                 from /usr/include/c++/6.3.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.3.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.3.1/ios:42,
                 from /usr/include/c++/6.3.1/ostream:38,
                 from /usr/include/c++/6.3.1/iostream:39,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/Rstream.hpp:10,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:36,
                 from stockassessment.cpp:33:
/usr/include/c++/6.3.1/backward/binders.h:143:11: note: declared here
     class binder2nd
           ^~~~~~~~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Core:276:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Dense:1,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:53,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/Functors.h:977:28: warning: ‘template<class _Operation> class std::binder1st’ is deprecated [-Wdeprecated-declarations]
 struct functor_traits<std::binder1st<T> >
                            ^~~~~~~~~
In file included from /usr/include/c++/6.3.1/bits/stl_function.h:1127:0,
                 from /usr/include/c++/6.3.1/string:48,
                 from /usr/include/c++/6.3.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.3.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.3.1/ios:42,
                 from /usr/include/c++/6.3.1/ostream:38,
                 from /usr/include/c++/6.3.1/iostream:39,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/Rstream.hpp:10,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:36,
                 from stockassessment.cpp:33:
/usr/include/c++/6.3.1/backward/binders.h:108:11: note: declared here
     class binder1st
           ^~~~~~~~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Core:326:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Dense:1,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:53,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/products/GeneralBlockPanelKernel.h: In member function ‘void Eigen::internal::gebp_kernel<LhsScalar, RhsScalar, Index, mr, nr, ConjugateLhs, ConjugateRhs>::operator()(Eigen::internal::gebp_kernel<LhsScalar, RhsScalar, Index, mr, nr, ConjugateLhs, ConjugateRhs>::ResScalar*, Index, const LhsScalar*, const RhsScalar*, Index, Index, Index, Eigen::internal::gebp_kernel<LhsScalar, RhsScalar, Index, mr, nr, ConjugateLhs, ConjugateRhs>::ResScalar, Index, Index, Index, Index, RhsScalar*)’:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/products/GeneralBlockPanelKernel.h:574:9: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
         if(nr==4) traits.initAcc(C3);
         ^~
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/products/GeneralBlockPanelKernel.h:575:19: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
                   traits.initAcc(C4);
                   ^~~~~~
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/products/GeneralBlockPanelKernel.h:946:9: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
         if(nr==4) R3 = ploadu<ResPacket>(r3);
         ^~
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/products/GeneralBlockPanelKernel.h:948:19: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
                   traits.acc(C0, alphav, R0);
                   ^~~~~~
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/products/GeneralBlockPanelKernel.h:951:9: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
         if(nr==4) traits.acc(C3, alphav, R3);
         ^~
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/Core/products/GeneralBlockPanelKernel.h:953:19: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
                   pstoreu(r0, R0);
                   ^~~~~~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/SparseLU:29:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Sparse:22,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:54,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/SparseLU/SparseLU_gemm_kernel.h: In function ‘void Eigen::internal::sparselu_gemm(Index, Index, Index, const Scalar*, Index, const Scalar*, Index, Scalar*, Index)’:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/SparseLU/SparseLU_gemm_kernel.h:78:9: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
         if(RK==4) b30 = pset1<Packet>(Bc0[3]);
         ^~
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/src/SparseLU/SparseLU_gemm_kernel.h:79:19: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
                   b01 = pset1<Packet>(Bc1[0]);
                   ^~~
stockassessment.cpp: In instantiation of ‘Type objective_function<Type>::operator()() [with Type = double]’:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/tmb_core.hpp:1247:36:   required from here
stockassessment.cpp:312:47: error: call of overloaded ‘abs(double)’ is ambiguous
         fcor(i,j)=pow(trans(itrans_rho(0)),abs(Type(i-j)));
                                            ~~~^~~~~~~~~~~
In file included from /usr/include/c++/6.3.1/cstdlib:75:0,
                 from /usr/include/c++/6.3.1/ext/string_conversions.h:41,
                 from /usr/include/c++/6.3.1/bits/basic_string.h:5402,
                 from /usr/include/c++/6.3.1/string:52,
                 from /usr/include/c++/6.3.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.3.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.3.1/ios:42,
                 from /usr/include/c++/6.3.1/ostream:38,
                 from /usr/include/c++/6.3.1/iostream:39,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/Rstream.hpp:10,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:36,
                 from stockassessment.cpp:33:
/usr/include/stdlib.h:774:12: note: candidate: int abs(int)
 extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
            ^~~
In file included from /usr/include/c++/6.3.1/complex:44:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Core:28,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Dense:1,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:53,
                 from stockassessment.cpp:33:
/usr/include/c++/6.3.1/cmath:95:3: note: candidate: constexpr long double std::abs(long double)
   abs(long double __x)
   ^~~
/usr/include/c++/6.3.1/cmath:91:3: note: candidate: constexpr float std::abs(float)
   abs(float __x)
   ^~~
/usr/include/c++/6.3.1/cmath:85:3: note: candidate: constexpr double std::abs(double)
   abs(double __x)
   ^~~
In file included from /usr/include/c++/6.3.1/ext/string_conversions.h:41:0,
                 from /usr/include/c++/6.3.1/bits/basic_string.h:5402,
                 from /usr/include/c++/6.3.1/string:52,
                 from /usr/include/c++/6.3.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.3.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.3.1/ios:42,
                 from /usr/include/c++/6.3.1/ostream:38,
                 from /usr/include/c++/6.3.1/iostream:39,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/Rstream.hpp:10,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:36,
                 from stockassessment.cpp:33:
/usr/include/c++/6.3.1/cstdlib:185:3: note: candidate: __int128 std::abs(__int128)
   abs(__GLIBCXX_TYPE_INT_N_0 __x) { return __x >= 0 ? __x : -__x; }
   ^~~
/usr/include/c++/6.3.1/cstdlib:180:3: note: candidate: long long int std::abs(long long int)
   abs(long long __x) { return __builtin_llabs (__x); }
   ^~~
/usr/include/c++/6.3.1/cstdlib:172:3: note: candidate: long int std::abs(long int)
   abs(long __i) { return __builtin_labs(__i); }
   ^~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/base_require.hpp:161:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/cppad.hpp:22,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:59,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_complex.hpp:373:23: note: candidate: std::complex<float> CppAD::abs(const std::complex<float>&)
  CPPAD_USER_MACRO_TWO(abs)
                       ^
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_complex.hpp:307:28: note: in definition of macro ‘CPPAD_USER_MACRO_TWO’
 inline std::complex<float> Fun(const std::complex<float>& x)       \
                            ^~~
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_complex.hpp:241:19: note: candidate: std::complex<double> CppAD::abs(const std::complex<double>&)
  CPPAD_USER_MACRO(abs)
                   ^
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_complex.hpp:232:29: note: in definition of macro ‘CPPAD_USER_MACRO’
 inline std::complex<double> Fun(const std::complex<double>& x)     \
                             ^~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/base_require.hpp:160:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/cppad.hpp:22,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:59,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_double.hpp:157:16: note: candidate: double CppAD::abs(const double&)
  inline double abs(const double& x)
                ^~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/base_require.hpp:159:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/cppad.hpp:22,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:59,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_float.hpp:158:15: note: candidate: float CppAD::abs(const float&)
  inline float abs(const float& x)
               ^~~
stockassessment.cpp:588:20: error: call of overloaded ‘abs(double)’ is ambiguous
      ans -= log(abs(jacobianDet((vector<Type>)logobs.segment(idxfrom,idxlength).exp())));
                 ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/6.3.1/cstdlib:75:0,
                 from /usr/include/c++/6.3.1/ext/string_conversions.h:41,
                 from /usr/include/c++/6.3.1/bits/basic_string.h:5402,
                 from /usr/include/c++/6.3.1/string:52,
                 from /usr/include/c++/6.3.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.3.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.3.1/ios:42,
                 from /usr/include/c++/6.3.1/ostream:38,
                 from /usr/include/c++/6.3.1/iostream:39,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/Rstream.hpp:10,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:36,
                 from stockassessment.cpp:33:
/usr/include/stdlib.h:774:12: note: candidate: int abs(int)
 extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
            ^~~
In file included from /usr/include/c++/6.3.1/complex:44:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Core:28,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/RcppEigen/include/Eigen/Dense:1,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:53,
                 from stockassessment.cpp:33:
/usr/include/c++/6.3.1/cmath:95:3: note: candidate: constexpr long double std::abs(long double)
   abs(long double __x)
   ^~~
/usr/include/c++/6.3.1/cmath:91:3: note: candidate: constexpr float std::abs(float)
   abs(float __x)
   ^~~
/usr/include/c++/6.3.1/cmath:85:3: note: candidate: constexpr double std::abs(double)
   abs(double __x)
   ^~~
In file included from /usr/include/c++/6.3.1/ext/string_conversions.h:41:0,
                 from /usr/include/c++/6.3.1/bits/basic_string.h:5402,
                 from /usr/include/c++/6.3.1/string:52,
                 from /usr/include/c++/6.3.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.3.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.3.1/ios:42,
                 from /usr/include/c++/6.3.1/ostream:38,
                 from /usr/include/c++/6.3.1/iostream:39,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/Rstream.hpp:10,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:36,
                 from stockassessment.cpp:33:
/usr/include/c++/6.3.1/cstdlib:185:3: note: candidate: __int128 std::abs(__int128)
   abs(__GLIBCXX_TYPE_INT_N_0 __x) { return __x >= 0 ? __x : -__x; }
   ^~~
/usr/include/c++/6.3.1/cstdlib:180:3: note: candidate: long long int std::abs(long long int)
   abs(long long __x) { return __builtin_llabs (__x); }
   ^~~
/usr/include/c++/6.3.1/cstdlib:172:3: note: candidate: long int std::abs(long int)
   abs(long __i) { return __builtin_labs(__i); }
   ^~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/base_require.hpp:161:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/cppad.hpp:22,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:59,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_complex.hpp:373:23: note: candidate: std::complex<float> CppAD::abs(const std::complex<float>&)
  CPPAD_USER_MACRO_TWO(abs)
                       ^
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_complex.hpp:307:28: note: in definition of macro ‘CPPAD_USER_MACRO_TWO’
 inline std::complex<float> Fun(const std::complex<float>& x)       \
                            ^~~
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_complex.hpp:241:19: note: candidate: std::complex<double> CppAD::abs(const std::complex<double>&)
  CPPAD_USER_MACRO(abs)
                   ^
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_complex.hpp:232:29: note: in definition of macro ‘CPPAD_USER_MACRO’
 inline std::complex<double> Fun(const std::complex<double>& x)     \
                             ^~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/base_require.hpp:160:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/cppad.hpp:22,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:59,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_double.hpp:157:16: note: candidate: double CppAD::abs(const double&)
  inline double abs(const double& x)
                ^~~
In file included from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/base_require.hpp:159:0,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/cppad.hpp:22,
                 from /home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/TMB.hpp:59,
                 from stockassessment.cpp:33:
/home/user/R/x86_64-redhat-linux-gnu-library/3.3/TMB/include/cppad/local/base_float.hpp:158:15: note: candidate: float CppAD::abs(const float&)
  inline float abs(const float& x)
               ^~~
/usr/lib64/R/etc/Makeconf:139: recipe for target 'stockassessment.o' failed
make: *** [stockassessment.o] Error 1
ERROR: compilation failed for package ‘stockassessment’
* removing ‘/home/user/R/x86_64-redhat-linux-gnu-library/3.3/stockassessment’
Error: Command failed (1)
```
GCC information:
```
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/6.3.1/lto-wrapper
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,objc,obj-c++,fortran,ada,go,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --disable-libgcj --with-isl --enable-libmpx --enable-gnu-indirect-function --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux
Thread model: posix
gcc version 6.3.1 20161221 (Red Hat 6.3.1-1) (GCC)
```