### PR TITLE
Remove file.exists(filen) to allow reading URL

### DIFF
--- a/stockassessment/R/reading.R
+++ b/stockassessment/R/reading.R
@@ -30,11 +30,6 @@ is.whole.positive.number <- function(x, tol = .Machine$double.eps^0.5){
 ##' @details ...
 read.surveys<-function(filen){
   # Function to read ices survey file 
-
-  if(!file.exists(filen)){
-    stop(paste("File",filen, "does not exsist"))
-  }
-
   lin<-readLines(filen,warn=FALSE)[-c(1:2)]
   empty<-which(lapply(lapply(strsplit(lin, split='[[:space:]]+'), 
                paste, collapse=''), nchar)==0)

--- a/stockassessment/R/reading.R
+++ b/stockassessment/R/reading.R
@@ -132,11 +132,6 @@ read.surveys<-function(filen){
 ##' Returns: A validated data matrix.
 ##' @export
 read.ices<-function(filen){
-
-  if(!file.exists(filen)){
-    stop(paste("File",filen, "does not exsist"))
-  }
-
   if(grepl("^[0-9]", scan(filen, skip=2, n=1, quiet=TRUE, what=""))){ # is not a survey file 
     
     head<-scan(filen, skip=2, n=5, quiet=TRUE)


### PR DESCRIPTION
By removing the file.exists() test, read.ices() can read data from URL. Way cool.

If file is not found, the default system error message seems quite accurate and sufficient.